### PR TITLE
docs: Update installation command in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Use precompiled versions in [releases page](https://github.com/ItsJimi/req/relea
 or
 
 ```shell
-go get -u github.com/itsjimi/req
+go install github.com/ItsJimi/req@latest
 ```
 
 ## Usage


### PR DESCRIPTION
## Problem

We can't use `go get -u` to install outside go project.

## Solution

Using `go install`.